### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.3.0",
-    "svg-to-img": "^2.0.9"
+    "svg-to-img": "^2.0.9",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@types/dom-to-image": "^2.6.7",

--- a/src/components/LeetCodeCard.tsx
+++ b/src/components/LeetCodeCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchLeetCodeData } from '../utils/leetcode';
+import he from 'he';
 
 type LeetCodeCardProps = {
   username: string;
@@ -33,7 +34,7 @@ const LeetCodeCard: React.FC<LeetCodeCardProps> = ({ username,type, theme, borde
   }
 
   // Construct the image URL using props
-  const imgUrl = `http://leetcode-status.vercel.app/api/${type}/${username}?theme=${theme}&border=${border}&hide_title=${hide_title}&custom_title=${custom_title}`;
+  const imgUrl = `http://leetcode-status.vercel.app/api/${he.encode(type)}/${he.encode(username)}?theme=${he.encode(theme)}&border=${border}&hide_title=${hide_title}&custom_title=${he.encode(custom_title)}`;
 
   return (
     <div className='flex items-center justify-center rounded'>


### PR DESCRIPTION
Fixes [https://github.com/iyehah/leetcode-status/security/code-scanning/1](https://github.com/iyehah/leetcode-status/security/code-scanning/1)

To fix the problem, we need to ensure that the user inputs are properly sanitized before being used to construct the `imgUrl`. This can be achieved by encoding the user inputs to prevent any malicious content from being interpreted as HTML.

- Use a library like `he` (HTML entities) to encode the user inputs before constructing the `imgUrl`.
- Update the `LeetCodeCard.tsx` file to include the necessary imports and encode the user inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
